### PR TITLE
Fixing edge case where there are no previous tags

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -61,9 +61,14 @@ jobs:
     - name: Compare With Previous Release
       id: compare_previous_release
       run: |
-        if [ -z "$(git diff $(git describe --tags --abbrev=0) -- builder-buildpackless.toml)" ]
-        then
-          echo "builder_changes=false" >> "$GITHUB_OUTPUT"
+        latest_tag=$(git describe --tags --abbrev=0 2>/dev/null)
+
+        if [ "$latest_tag" ]; then
+          if [ -z "$(git diff "$latest_tag" -- builder-buildpackless.toml)" ]; then
+            echo "builder_changes=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "builder_changes=true" >> "$GITHUB_OUTPUT"
+          fi
         else
           echo "builder_changes=true" >> "$GITHUB_OUTPUT"
         fi


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
This PR fixes an edge case on the create-release workflow where it fails in case there are no previous releases.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
